### PR TITLE
Add TypeLauncher to software page

### DIFF
--- a/templates/software.jinja
+++ b/templates/software.jinja
@@ -7,6 +7,8 @@
         <dd>Simpler, safer sudo</dd>
         <dt><a href="https://addons.mozilla.org/en-US/firefox/addon/tabs-menu/">Tabs Menu</a></dt>
         <dd>Adds a Tabs menu to Firefox so you can easily switch tabs</dd>
+        <dt><a href="https://play.google.com/store/apps/details?id=app.typelauncher">TypeLauncher</a> (<a href="https://github.com/mikelward/typelauncher">GitHub</a>)</dt>
+        <dd>A fast Android app launcher with dock, widgets, and fuzzy find</dd>
         <dt><a href="https://github.com/mikelward/conf">conf</a> (<a href="https://github.com/mikelward/conf">GitHub</a>)</dt>
         <dd>Linux, Mac, and Windows system configuration files</dd>
         <dt><a href="https://github.com/mikelward/scripts">scripts</a> (<a href="https://github.com/mikelward/scripts">GitHub</a>)</dt>


### PR DESCRIPTION
Add TypeLauncher (a fast Android app launcher) to the software projects page, linking to its Play Store listing and GitHub repository.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LBu1df8qS77RXBJtjL6GE2)_