### PR TITLE
Add ClothesCast to software projects page

### DIFF
--- a/templates/software.jinja
+++ b/templates/software.jinja
@@ -5,6 +5,8 @@
         <dd>Unofficial mobile-optimized version of news.ycombinator.com</dd>
         <dt><a href="https://github.com/mikelward/root">root</a> (<a href="https://github.com/mikelward/root">GitHub</a>)</dt>
         <dd>Simpler, safer sudo</dd>
+        <dt><a href="https://play.google.com/store/apps/details?id=app.clothescast">ClothesCast</a> (<a href="https://github.com/mikelward/clothescast">GitHub</a>)</dt>
+        <dd>Know what to wear based on the weather</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.typelauncher">Type Launcher</a> (<a href="https://github.com/mikelward/typelauncher">GitHub</a>)</dt>
         <dd>A fast Android app launcher with dock, widgets, and fuzzy find</dd>
         <dt><a href="https://github.com/mikelward/conf">conf</a> (<a href="https://github.com/mikelward/conf">GitHub</a>)</dt>


### PR DESCRIPTION
## Summary

- Adds ClothesCast to the software projects page
- Links to the Play Store listing and the mikelward/clothescast GitHub repo
- Description: "Know what to wear based on the weather"

https://claude.ai/code/session_01Nmu7RkorgQHkq12pnUpUy8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nmu7RkorgQHkq12pnUpUy8)_