### PR TITLE
Add 2026 Senior SWE role and simplify full-stack wording

### DIFF
--- a/templates/resume.jinja
+++ b/templates/resume.jinja
@@ -21,12 +21,26 @@
       <h2 id="employment">Employment History</h2>
       <table>
         <tr>
-          <td class="date">2022&mdash;present</td>
+          <td class="date">2026&mdash;present</td>
           <td class="description">
             <span class="title">Senior Software Engineer</span><br />
             <a href="http://www.google.com/">Google</a>, London, UK</a>
             <ul>
-              <li>Development of full-stack Web applications in C++, Go, Java, and Angular/TypeScript</li>
+              <li>Improving reliability and efficiency of ML training and storage</li>
+              <li>Development of full-stack applications in C++, Go, Java, Python, and Angular/TypeScript</li>
+              <li>On-call work</li>
+              <li>Mentoring and teaching</li>
+            </ul>
+          </td>
+        </tr>
+
+        <tr>
+          <td class="date">2022&mdash;2026</td>
+          <td class="description">
+            <span class="title">Senior Software Engineer</span><br />
+            <a href="http://www.google.com/">Google</a>, London, UK</a>
+            <ul>
+              <li>Development of full-stack applications in C++, Go, Java, and Angular/TypeScript</li>
               <li>Influencing and sharing incident response best practices</li>
               <li>On-call work</li>
               <li>Mentoring and teaching</li>
@@ -41,7 +55,7 @@
             <a href="http://www.google.com/">Google</a>, Mountain View, USA</a>
             <ul>
               <li>Development of internal systems applications in Python and Go</li>
-              <li>Development of full-stack Web applications in C++, Go, Polymer, and Angular/TypeScript</li>
+              <li>Development of full-stack applications in C++, Go, Polymer, and Angular/TypeScript</li>
               <li>Maintenance and provisioning of DNS, DHCP, IRC, load balancing, and other services</li>
               <li>System monitoring and alerting</li>
               <li>Disaster recovery testing</li>


### PR DESCRIPTION
## Summary
- Added a new employment row: **2026—present, Senior Software Engineer, Google, London, UK** with the provided bullets (ML training/storage reliability, full-stack development, on-call, mentoring).
- Capped the existing 2022 Senior Software Engineer row at **2022—2026** so there aren't two concurrent "present" entries.
- Changed all references from "full-stack Web applications" to "full-stack applications" (two occurrences).

## Notes
The existing role's end year was set to 2026 to avoid two overlapping "present" rows. Let me know if you'd prefer to keep that row open-ended instead.

https://claude.ai/code/session_01BtodUjhPK5LPBBqEA9Kx6N

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtodUjhPK5LPBBqEA9Kx6N)_