### PR TITLE
Add Projects section to resume

### DIFF
--- a/templates/resume.jinja
+++ b/templates/resume.jinja
@@ -200,16 +200,6 @@
     </div>
 
     <div>
-      <h2 id="other">Other</h2>
-      <p>Active contributor on the Stack Exchange network:</p>
-      <ul>
-        <li><a href="http://unix.stackexchange.com/users/3169/mikel">Unix &amp; Linux</a></li>
-        <li><a href="http://superuser.com/users/15334/mikel">Superuser</a></li>
-        <li><a href="http://stackoverflow.com/users/102182/mikel">Stackoverflow</a></li>
-      </ul>
-    </div>
-
-    <div>
       <h2 id="projects">Projects</h2>
       <dl>
         <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>
@@ -229,6 +219,16 @@
         <dt><a href="https://github.com/mikelward/vcs">vcs</a> (<a href="https://github.com/mikelward/vcs">GitHub</a>)</dt>
         <dd>Ergonomic wrapper around git, hg, and jj</dd>
       </dl>
+    </div>
+
+    <div>
+      <h2 id="other">Other</h2>
+      <p>Active contributor on the Stack Exchange network:</p>
+      <ul>
+        <li><a href="http://unix.stackexchange.com/users/3169/mikel">Unix &amp; Linux</a></li>
+        <li><a href="http://superuser.com/users/15334/mikel">Superuser</a></li>
+        <li><a href="http://stackoverflow.com/users/102182/mikel">Stackoverflow</a></li>
+      </ul>
     </div>
 
     <div>

--- a/templates/resume.jinja
+++ b/templates/resume.jinja
@@ -202,22 +202,20 @@
     <div>
       <h2 id="projects">Projects</h2>
       <dl>
-        <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>
-        <dd>View your family tree on a world map</dd>
+        <dt><a href="https://readmo.app">readmo.app</a> (<a href="https://github.com/mikelward/readmo">GitHub</a>)</dt>
+        <dd>A mobile- and offline-friendly RSS news reader</dd>
         <dt><a href="https://newshacker.app">newshacker.app</a> (<a href="https://github.com/mikelward/newshacker">GitHub</a>)</dt>
         <dd>Unofficial mobile-optimized version of news.ycombinator.com</dd>
-        <dt><a href="https://github.com/mikelward/root">root</a> (<a href="https://github.com/mikelward/root">GitHub</a>)</dt>
-        <dd>Simpler, safer sudo</dd>
-        <dt><a href="https://play.google.com/store/apps/details?id=app.clothescast">ClothesCast</a> (<a href="https://github.com/mikelward/clothescast">GitHub</a>)</dt>
-        <dd>Know what to wear based on the weather</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.typelauncher">Type Launcher</a> (<a href="https://github.com/mikelward/typelauncher">GitHub</a>)</dt>
         <dd>A fast Android app launcher with dock, widgets, and fuzzy find</dd>
-        <dt><a href="https://github.com/mikelward/conf">conf</a> (<a href="https://github.com/mikelward/conf">GitHub</a>)</dt>
-        <dd>Linux, Mac, and Windows system configuration files</dd>
-        <dt><a href="https://github.com/mikelward/scripts">scripts</a> (<a href="https://github.com/mikelward/scripts">GitHub</a>)</dt>
-        <dd>Small programs to accomplish common tasks</dd>
+        <dt><a href="https://play.google.com/store/apps/details?id=app.clothescast">ClothesCast</a> (<a href="https://github.com/mikelward/clothescast">GitHub</a>)</dt>
+        <dd>Know what to wear based on the weather</dd>
+        <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>
+        <dd>View your family tree on a world map</dd>
         <dt><a href="https://github.com/mikelward/vcs">vcs</a> (<a href="https://github.com/mikelward/vcs">GitHub</a>)</dt>
         <dd>Ergonomic wrapper around git, hg, and jj</dd>
+        <dt><a href="https://github.com/mikelward/root">root</a> (<a href="https://github.com/mikelward/root">GitHub</a>)</dt>
+        <dd>Simpler, safer sudo</dd>
       </dl>
     </div>
 

--- a/templates/resume.jinja
+++ b/templates/resume.jinja
@@ -210,6 +210,28 @@
     </div>
 
     <div>
+      <h2 id="projects">Projects</h2>
+      <dl>
+        <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>
+        <dd>View your family tree on a world map</dd>
+        <dt><a href="https://newshacker.app">newshacker.app</a> (<a href="https://github.com/mikelward/newshacker">GitHub</a>)</dt>
+        <dd>Unofficial mobile-optimized version of news.ycombinator.com</dd>
+        <dt><a href="https://github.com/mikelward/root">root</a> (<a href="https://github.com/mikelward/root">GitHub</a>)</dt>
+        <dd>Simpler, safer sudo</dd>
+        <dt><a href="https://play.google.com/store/apps/details?id=app.clothescast">ClothesCast</a> (<a href="https://github.com/mikelward/clothescast">GitHub</a>)</dt>
+        <dd>Know what to wear based on the weather</dd>
+        <dt><a href="https://play.google.com/store/apps/details?id=app.typelauncher">Type Launcher</a> (<a href="https://github.com/mikelward/typelauncher">GitHub</a>)</dt>
+        <dd>A fast Android app launcher with dock, widgets, and fuzzy find</dd>
+        <dt><a href="https://github.com/mikelward/conf">conf</a> (<a href="https://github.com/mikelward/conf">GitHub</a>)</dt>
+        <dd>Linux, Mac, and Windows system configuration files</dd>
+        <dt><a href="https://github.com/mikelward/scripts">scripts</a> (<a href="https://github.com/mikelward/scripts">GitHub</a>)</dt>
+        <dd>Small programs to accomplish common tasks</dd>
+        <dt><a href="https://github.com/mikelward/vcs">vcs</a> (<a href="https://github.com/mikelward/vcs">GitHub</a>)</dt>
+        <dd>Ergonomic wrapper around git, hg, and jj</dd>
+      </dl>
+    </div>
+
+    <div>
       <h2 id="referees">Referees</h2>
       <p>Please <a href="http://mikelward.com/contact">contact me</a> for details of my referees.</p>
     </div>

--- a/templates/resume.jinja
+++ b/templates/resume.jinja
@@ -206,16 +206,20 @@
         <dd>A mobile- and offline-friendly RSS news reader</dd>
         <dt><a href="https://newshacker.app">newshacker.app</a> (<a href="https://github.com/mikelward/newshacker">GitHub</a>)</dt>
         <dd>Unofficial mobile-optimized version of news.ycombinator.com</dd>
-        <dt><a href="https://play.google.com/store/apps/details?id=app.typelauncher">Type Launcher</a> (<a href="https://github.com/mikelward/typelauncher">GitHub</a>)</dt>
-        <dd>A fast Android app launcher with dock, widgets, and fuzzy find</dd>
-        <dt><a href="https://play.google.com/store/apps/details?id=app.clothescast">ClothesCast</a> (<a href="https://github.com/mikelward/clothescast">GitHub</a>)</dt>
-        <dd>Know what to wear based on the weather</dd>
         <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>
         <dd>View your family tree on a world map</dd>
-        <dt><a href="https://github.com/mikelward/vcs">vcs</a> (<a href="https://github.com/mikelward/vcs">GitHub</a>)</dt>
-        <dd>Ergonomic wrapper around git, hg, and jj</dd>
+        <dt><a href="https://play.google.com/store/apps/details?id=app.clothescast">ClothesCast</a> (<a href="https://github.com/mikelward/clothescast">GitHub</a>)</dt>
+        <dd>Know what to wear based on the weather</dd>
+        <dt><a href="https://play.google.com/store/apps/details?id=app.typelauncher">Type Launcher</a> (<a href="https://github.com/mikelward/typelauncher">GitHub</a>)</dt>
+        <dd>A fast Android app launcher with dock, widgets, and fuzzy find</dd>
         <dt><a href="https://github.com/mikelward/root">root</a> (<a href="https://github.com/mikelward/root">GitHub</a>)</dt>
         <dd>Simpler, safer sudo</dd>
+        <dt><a href="https://github.com/mikelward/vcs">vcs</a> (<a href="https://github.com/mikelward/vcs">GitHub</a>)</dt>
+        <dd>Ergonomic wrapper around git, hg, and jj</dd>
+        <dt><a href="https://github.com/mikelward/scripts">scripts</a> (<a href="https://github.com/mikelward/scripts">GitHub</a>)</dt>
+        <dd>Small programs to accomplish common tasks</dd>
+        <dt><a href="https://github.com/mikelward/conf">conf</a> (<a href="https://github.com/mikelward/conf">GitHub</a>)</dt>
+        <dd>Linux, Mac, and Windows system configuration files</dd>
       </dl>
     </div>
 

--- a/templates/software.jinja
+++ b/templates/software.jinja
@@ -1,18 +1,20 @@
     <dl>
-        <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>
-        <dd>View your family tree on a world map</dd>
+        <dt><a href="https://readmo.app">readmo.app</a> (<a href="https://github.com/mikelward/readmo">GitHub</a>)</dt>
+        <dd>A mobile- and offline-friendly RSS news reader</dd>
         <dt><a href="https://newshacker.app">newshacker.app</a> (<a href="https://github.com/mikelward/newshacker">GitHub</a>)</dt>
         <dd>Unofficial mobile-optimized version of news.ycombinator.com</dd>
-        <dt><a href="https://github.com/mikelward/root">root</a> (<a href="https://github.com/mikelward/root">GitHub</a>)</dt>
-        <dd>Simpler, safer sudo</dd>
+        <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>
+        <dd>View your family tree on a world map</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.clothescast">ClothesCast</a> (<a href="https://github.com/mikelward/clothescast">GitHub</a>)</dt>
         <dd>Know what to wear based on the weather</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.typelauncher">Type Launcher</a> (<a href="https://github.com/mikelward/typelauncher">GitHub</a>)</dt>
         <dd>A fast Android app launcher with dock, widgets, and fuzzy find</dd>
-        <dt><a href="https://github.com/mikelward/conf">conf</a> (<a href="https://github.com/mikelward/conf">GitHub</a>)</dt>
-        <dd>Linux, Mac, and Windows system configuration files</dd>
-        <dt><a href="https://github.com/mikelward/scripts">scripts</a> (<a href="https://github.com/mikelward/scripts">GitHub</a>)</dt>
-        <dd>Small programs to accomplish common tasks</dd>
+        <dt><a href="https://github.com/mikelward/root">root</a> (<a href="https://github.com/mikelward/root">GitHub</a>)</dt>
+        <dd>Simpler, safer sudo</dd>
         <dt><a href="https://github.com/mikelward/vcs">vcs</a> (<a href="https://github.com/mikelward/vcs">GitHub</a>)</dt>
         <dd>Ergonomic wrapper around git, hg, and jj</dd>
+        <dt><a href="https://github.com/mikelward/scripts">scripts</a> (<a href="https://github.com/mikelward/scripts">GitHub</a>)</dt>
+        <dd>Small programs to accomplish common tasks</dd>
+        <dt><a href="https://github.com/mikelward/conf">conf</a> (<a href="https://github.com/mikelward/conf">GitHub</a>)</dt>
+        <dd>Linux, Mac, and Windows system configuration files</dd>
     </dl>


### PR DESCRIPTION
## Summary

Adds a **Projects** section to the bottom of the resume (`/resume`), just above the Referees section.

The projects mirror the entries already listed on the Software page (`templates/software.jinja`): gedmap.com, newshacker.app, root, ClothesCast, Type Launcher, conf, scripts, and vcs. Each links to the project site (where applicable) and its GitHub repo, using the same `<dl>` markup as the Software page for visual consistency.

## Changes

- `templates/resume.jinja`: new `<h2 id="projects">Projects</h2>` block with a definition list of projects, placed before the Referees section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTPCa5PjnwvDvwyHypCnCK)_