### PR TITLE
Refresh project descriptions on resume and software pages

### DIFF
--- a/templates/resume.jinja
+++ b/templates/resume.jinja
@@ -205,7 +205,7 @@
         <dt><a href="https://readmo.app">readmo.app</a> (<a href="https://github.com/mikelward/readmo">GitHub</a>)</dt>
         <dd>A mobile- and offline-friendly RSS news reader</dd>
         <dt><a href="https://newshacker.app">newshacker.app</a> (<a href="https://github.com/mikelward/newshacker">GitHub</a>)</dt>
-        <dd>Unofficial mobile-optimized version of news.ycombinator.com</dd>
+        <dd>Mobile-optimized version of news.ycombinator.com with AI summaries.</dd>
         <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>
         <dd>View your family tree on a world map</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.clothescast">ClothesCast</a> (<a href="https://github.com/mikelward/clothescast">GitHub</a>)</dt>

--- a/templates/resume.jinja
+++ b/templates/resume.jinja
@@ -203,7 +203,7 @@
       <h2 id="projects">Projects</h2>
       <dl>
         <dt><a href="https://readmo.app">readmo.app</a> (<a href="https://github.com/mikelward/readmo">GitHub</a>)</dt>
-        <dd>A mobile- and offline-friendly RSS news reader</dd>
+        <dd>A mobile-optimized RSS news reader with offline support</dd>
         <dt><a href="https://newshacker.app">newshacker.app</a> (<a href="https://github.com/mikelward/newshacker">GitHub</a>)</dt>
         <dd>Mobile-optimized version of news.ycombinator.com with AI summaries.</dd>
         <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>

--- a/templates/resume.jinja
+++ b/templates/resume.jinja
@@ -202,10 +202,10 @@
     <div>
       <h2 id="projects">Projects</h2>
       <dl>
-        <dt><a href="https://readmo.app">readmo.app</a> (<a href="https://github.com/mikelward/readmo">GitHub</a>)</dt>
-        <dd>A mobile-optimized RSS news reader with offline support</dd>
         <dt><a href="https://newshacker.app">newshacker.app</a> (<a href="https://github.com/mikelward/newshacker">GitHub</a>)</dt>
         <dd>Mobile-optimized version of news.ycombinator.com with AI summaries.</dd>
+        <dt><a href="https://readmo.app">readmo.app</a> (<a href="https://github.com/mikelward/readmo">GitHub</a>)</dt>
+        <dd>A mobile-optimized RSS news reader with offline support</dd>
         <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>
         <dd>View your family tree on a world map</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.clothescast">ClothesCast</a> (<a href="https://github.com/mikelward/clothescast">GitHub</a>)</dt>

--- a/templates/software.jinja
+++ b/templates/software.jinja
@@ -1,8 +1,8 @@
     <dl>
-        <dt><a href="https://readmo.app">readmo.app</a> (<a href="https://github.com/mikelward/readmo">GitHub</a>)</dt>
-        <dd>A mobile-optimized RSS news reader with offline support</dd>
         <dt><a href="https://newshacker.app">newshacker.app</a> (<a href="https://github.com/mikelward/newshacker">GitHub</a>)</dt>
         <dd>Mobile-optimized version of news.ycombinator.com with AI summaries.</dd>
+        <dt><a href="https://readmo.app">readmo.app</a> (<a href="https://github.com/mikelward/readmo">GitHub</a>)</dt>
+        <dd>A mobile-optimized RSS news reader with offline support</dd>
         <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>
         <dd>View your family tree on a world map</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.clothescast">ClothesCast</a> (<a href="https://github.com/mikelward/clothescast">GitHub</a>)</dt>

--- a/templates/software.jinja
+++ b/templates/software.jinja
@@ -2,7 +2,7 @@
         <dt><a href="https://readmo.app">readmo.app</a> (<a href="https://github.com/mikelward/readmo">GitHub</a>)</dt>
         <dd>A mobile- and offline-friendly RSS news reader</dd>
         <dt><a href="https://newshacker.app">newshacker.app</a> (<a href="https://github.com/mikelward/newshacker">GitHub</a>)</dt>
-        <dd>Unofficial mobile-optimized version of news.ycombinator.com</dd>
+        <dd>Mobile-optimized version of news.ycombinator.com with AI summaries.</dd>
         <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>
         <dd>View your family tree on a world map</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.clothescast">ClothesCast</a> (<a href="https://github.com/mikelward/clothescast">GitHub</a>)</dt>

--- a/templates/software.jinja
+++ b/templates/software.jinja
@@ -1,6 +1,6 @@
     <dl>
         <dt><a href="https://readmo.app">readmo.app</a> (<a href="https://github.com/mikelward/readmo">GitHub</a>)</dt>
-        <dd>A mobile- and offline-friendly RSS news reader</dd>
+        <dd>A mobile-optimized RSS news reader with offline support</dd>
         <dt><a href="https://newshacker.app">newshacker.app</a> (<a href="https://github.com/mikelward/newshacker">GitHub</a>)</dt>
         <dd>Mobile-optimized version of news.ycombinator.com with AI summaries.</dd>
         <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>


### PR DESCRIPTION
Updates two project descriptions on both the resume and software pages.

**newshacker.app**
- Before: "Unofficial mobile-optimized version of news.ycombinator.com"
- After: "Mobile-optimized version of news.ycombinator.com with AI summaries."

**readmo.app**
- Before: "A mobile- and offline-friendly RSS news reader"
- After: "A mobile-optimized RSS news reader with offline support"

Changed in:
- `templates/resume.jinja`
- `templates/software.jinja`

🤖 Generated with [Claude Code](https://claude.com/claude-code)