### PR TITLE
Remove trailing dot from newshacker description

### DIFF
--- a/templates/resume.jinja
+++ b/templates/resume.jinja
@@ -203,7 +203,7 @@
       <h2 id="projects">Projects</h2>
       <dl>
         <dt><a href="https://newshacker.app">newshacker.app</a> (<a href="https://github.com/mikelward/newshacker">GitHub</a>)</dt>
-        <dd>Mobile-optimized version of news.ycombinator.com with AI summaries.</dd>
+        <dd>Mobile-optimized version of news.ycombinator.com with AI summaries</dd>
         <dt><a href="https://readmo.app">readmo.app</a> (<a href="https://github.com/mikelward/readmo">GitHub</a>)</dt>
         <dd>A mobile-optimized RSS news reader with offline support</dd>
         <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>

--- a/templates/software.jinja
+++ b/templates/software.jinja
@@ -1,6 +1,6 @@
     <dl>
         <dt><a href="https://newshacker.app">newshacker.app</a> (<a href="https://github.com/mikelward/newshacker">GitHub</a>)</dt>
-        <dd>Mobile-optimized version of news.ycombinator.com with AI summaries.</dd>
+        <dd>Mobile-optimized version of news.ycombinator.com with AI summaries</dd>
         <dt><a href="https://readmo.app">readmo.app</a> (<a href="https://github.com/mikelward/readmo">GitHub</a>)</dt>
         <dd>A mobile-optimized RSS news reader with offline support</dd>
         <dt><a href="https://gedmap.com">gedmap.com</a> (<a href="https://github.com/mikelward/gedmap">GitHub</a>)</dt>


### PR DESCRIPTION
Removes the trailing dot from the newshacker.app description for consistency with the other project descriptions.

- Before: "Mobile-optimized version of news.ycombinator.com with AI summaries."
- After: "Mobile-optimized version of news.ycombinator.com with AI summaries"

Changed in:
- `templates/resume.jinja`
- `templates/software.jinja`

🤖 Generated with [Claude Code](https://claude.com/claude-code)