### PR TITLE
Add Simmo to software projects list

### DIFF
--- a/templates/software.jinja
+++ b/templates/software.jinja
@@ -9,6 +9,8 @@
         <dd>Know what to wear based on the weather</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.typelauncher">Type Launcher</a> (<a href="https://github.com/mikelward/typelauncher">GitHub</a>)</dt>
         <dd>A fast Android app launcher with dock, widgets, and fuzzy find</dd>
+        <dt><a href="https://github.com/mikelward/simmo">Simmo</a> (<a href="https://github.com/mikelward/simmo">GitHub</a>)</dt>
+        <dd>Automatically use the right SIM</dd>
         <dt><a href="https://github.com/mikelward/root">root</a> (<a href="https://github.com/mikelward/root">GitHub</a>)</dt>
         <dd>Simpler, safer sudo</dd>
         <dt><a href="https://github.com/mikelward/vcs">vcs</a> (<a href="https://github.com/mikelward/vcs">GitHub</a>)</dt>


### PR DESCRIPTION
Adds Simmo to the software page, linked to its GitHub repo (it's not on the Play Store yet), with the description "Automatically use the right SIM". Placed after Type Launcher, alongside the other GitHub-only projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z1CvbP7rKzwydG7PBXkNa

---
_Generated by [Claude Code](https://claude.ai/code/session_019z1CvbP7rKzwydG7PBXkNa)_