### PR TITLE
Add mesh and reposition Simmo on software page

### DIFF
--- a/templates/software.jinja
+++ b/templates/software.jinja
@@ -7,10 +7,12 @@
         <dd>View your family tree on a world map</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.clothescast">ClothesCast</a> (<a href="https://github.com/mikelward/clothescast">GitHub</a>)</dt>
         <dd>Know what to wear based on the weather</dd>
+        <dt><a href="https://github.com/mikelward/simmo">Simmo</a> (<a href="https://github.com/mikelward/simmo">GitHub</a>)</dt>
+        <dd>Always use the right SIM</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.typelauncher">Type Launcher</a> (<a href="https://github.com/mikelward/typelauncher">GitHub</a>)</dt>
         <dd>A fast Android app launcher with dock, widgets, and fuzzy find</dd>
-        <dt><a href="https://github.com/mikelward/simmo">Simmo</a> (<a href="https://github.com/mikelward/simmo">GitHub</a>)</dt>
-        <dd>Automatically use the right SIM</dd>
+        <dt><a href="https://github.com/mikelward/mesh">mesh</a> (<a href="https://github.com/mikelward/mesh">GitHub</a>)</dt>
+        <dd>Modern, ergonomic shell</dd>
         <dt><a href="https://github.com/mikelward/root">root</a> (<a href="https://github.com/mikelward/root">GitHub</a>)</dt>
         <dd>Simpler, safer sudo</dd>
         <dt><a href="https://github.com/mikelward/vcs">vcs</a> (<a href="https://github.com/mikelward/vcs">GitHub</a>)</dt>


### PR DESCRIPTION
Updates the software projects list in `templates/software.jinja`:

- Moved **Simmo** between ClothesCast and Type Launcher, and changed its description to "Always use the right SIM"
- Added **mesh** ("Modern, ergonomic shell") above root

Tests pass (`make test`: 8 tests, 2 skipped).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnuPeNRvB3M3uzivjkjKQw)_