### PR TITLE
Link Simmo to its Play Store listing

### DIFF
--- a/templates/software.jinja
+++ b/templates/software.jinja
@@ -7,7 +7,7 @@
         <dd>View your family tree on a world map</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.clothescast">ClothesCast</a> (<a href="https://github.com/mikelward/clothescast">GitHub</a>)</dt>
         <dd>Know what to wear based on the weather</dd>
-        <dt><a href="https://github.com/mikelward/simmo">Simmo</a> (<a href="https://github.com/mikelward/simmo">GitHub</a>)</dt>
+        <dt><a href="https://play.google.com/store/apps/details?id=app.simmo">Simmo</a> (<a href="https://github.com/mikelward/simmo">GitHub</a>)</dt>
         <dd>Always use the right SIM</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.typelauncher">Type Launcher</a> (<a href="https://github.com/mikelward/typelauncher">GitHub</a>)</dt>
         <dd>A fast Android app launcher with dock, widgets, and fuzzy find</dd>


### PR DESCRIPTION
Simmo's entry on the software page had its title link pointing at GitHub, duplicating the GitHub link right beside it. This points the title at the Play Store listing instead, matching how ClothesCast and Type Launcher are linked.

```diff
-<dt><a href="https://github.com/mikelward/simmo">Simmo</a> (<a href="https://github.com/mikelward/simmo">GitHub</a>)</dt>
+<dt><a href="https://play.google.com/store/apps/details?id=app.simmo">Simmo</a> (<a href="https://github.com/mikelward/simmo">GitHub</a>)</dt>
```

**Please confirm the package ID.** `play.google.com` is blocked by this environment's network policy, so I couldn't verify the listing. I used `app.simmo` based on the convention of the other two Play Store links on the page (`app.clothescast`, `app.typelauncher`). If the real ID differs, it's a one-word fix in `templates/software.jinja:10`.

`make test` passes (8 tests, 2 skipped).

---
_Generated by [Claude Code](https://claude.ai/code/session_019tAJCR9KtjvxjtJnTy5Jde)_