### PR TITLE
Mark Simmo as beta on software page

### DIFF
--- a/templates/software.jinja
+++ b/templates/software.jinja
@@ -7,7 +7,7 @@
         <dd>View your family tree on a world map</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.clothescast">ClothesCast</a> (<a href="https://github.com/mikelward/clothescast">GitHub</a>)</dt>
         <dd>Know what to wear based on the weather</dd>
-        <dt><a href="https://play.google.com/store/apps/details?id=app.simmo">Simmo</a> (<a href="https://github.com/mikelward/simmo">GitHub</a>)</dt>
+        <dt><a href="https://play.google.com/store/apps/details?id=app.simmo">Simmo (beta)</a> (<a href="https://github.com/mikelward/simmo">GitHub</a>)</dt>
         <dd>Always use the right SIM</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.typelauncher">Type Launcher</a> (<a href="https://github.com/mikelward/typelauncher">GitHub</a>)</dt>
         <dd>A fast Android app launcher with dock, widgets, and fuzzy find</dd>


### PR DESCRIPTION
Adds a "(beta)" label to the Simmo entry on the software page, inside the Play Store link text: `[Simmo (beta)](Play Store) ([GitHub](GitHub))`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RdYAF3mZRZmy7xVXyeXAc)_