### PR TITLE
Mark mesh as beta on software page

### DIFF
--- a/templates/software.jinja
+++ b/templates/software.jinja
@@ -11,7 +11,7 @@
         <dd>Always use the right SIM</dd>
         <dt><a href="https://play.google.com/store/apps/details?id=app.typelauncher">Type Launcher</a> (<a href="https://github.com/mikelward/typelauncher">GitHub</a>)</dt>
         <dd>A fast Android app launcher with dock, widgets, and fuzzy find</dd>
-        <dt><a href="https://github.com/mikelward/mesh">mesh</a> (<a href="https://github.com/mikelward/mesh">GitHub</a>)</dt>
+        <dt><a href="https://github.com/mikelward/mesh">mesh (beta)</a> (<a href="https://github.com/mikelward/mesh">GitHub</a>)</dt>
         <dd>Modern, ergonomic shell</dd>
         <dt><a href="https://github.com/mikelward/root">root</a> (<a href="https://github.com/mikelward/root">GitHub</a>)</dt>
         <dd>Simpler, safer sudo</dd>


### PR DESCRIPTION
Adds a "(beta)" suffix to the mesh entry on the software page, matching how Simmo is labelled.

```diff
-<dt><a href="https://github.com/mikelward/mesh">mesh</a> ...
+<dt><a href="https://github.com/mikelward/mesh">mesh (beta)</a> ...
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5dHvjpJ2SVcPRcryhMNNY)_