### PR TITLE
Add agent instructions covering PR and commit hygiene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md
+
+Conventions for AI agents working in this repository.
+
+`CLAUDE.md` is a symlink to this file, so every agent reads the same
+conventions. Edit `AGENTS.md`.
+
+## Git
+
+- Use `git worktree` when it's available. Give each branch its own worktree
+  instead of switching branches in place, so work in progress on one branch
+  isn't disturbed by work on another.
+- **One commit per logical change.** Rewrite unmerged commits freely — amend,
+  `git commit --fixup` + autosquash, squash, reorder, split — so each commit
+  that lands is one coherent change, with fix-ups and review responses folded
+  into the commit they belong to. `wip` / `address review` churn doesn't
+  survive into `main`.
+- `git push --force-with-lease` to your own live feature branch after a rebase
+  is routine hygiene — don't ask. Never a bare `--force`.
+
+## Pull requests
+
+- **On every push, update the PR title and body** so they describe the full,
+  latest state of the branch — not the scope it had when it was opened.
+  Re-read the diff against `origin/main` and patch whatever drifted, then post
+  the PR link in the chat reply for that push, not only at the end of the
+  conversation.
+- End every reply with the open-PR link (or `.../compare/main...<branch>`
+  until a PR exists). Never link to a closed or merged PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
This repo had no agent instructions file at all, so neither rule could apply here. Adds a minimal `AGENTS.md`, with `CLAUDE.md` as a symlink to it — the same layout the sibling repos use.

Contents kept deliberately small, covering only what was asked for plus the surrounding context it needs to make sense:

- *Pull requests*: on every push, update the PR title and body to the branch's latest state and post the PR link in that push's chat reply; end every reply with the open-PR link.
- *Git*: one commit per logical change, rewriting unmerged commits (amend, fixup/autosquash, squash, reorder, split) so fix-ups land folded into the commit they belong to; worktrees per branch; `--force-with-lease` over bare `--force`.

Documentation only — no application code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmPa3BqN3ds5dNZbNwwFRX)_